### PR TITLE
Remove non-existing system/bluetooth/main.conf from config

### DIFF
--- a/config/common_full_tablet_wifionly.mk
+++ b/config/common_full_tablet_wifionly.mk
@@ -7,10 +7,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.config.notification_sound=Deneb.ogg \
     ro.config.alarm_alert=Hassium.ogg
 
-# BT config
-PRODUCT_COPY_FILES += \
-    system/bluetooth/data/main.nonsmartphone.conf:system/etc/bluetooth/main.conf
-
 ifeq ($(TARGET_SCREEN_WIDTH) $(TARGET_SCREEN_HEIGHT),$(space))
     PRODUCT_COPY_FILES += \
 # Commenting out because we use the frameworks/base boot animation


### PR DESCRIPTION
This is gone in KitKat and causes some errors at build time. This fixes building.
