### PR TITLE
Don't inherit non-existing video makefiles

### DIFF
--- a/config/common_full.mk
+++ b/config/common_full.mk
@@ -7,9 +7,6 @@ include frameworks/base/data/sounds/NewAudio.mk
 # Extra Ringtones
 include frameworks/base/data/sounds/AudioPackageNewWave.mk
 
-# Bring in all video files
-$(call inherit-product, frameworks/base/data/videos/VideoPackage2.mk)
-
 # Optional Carbon packages
 PRODUCT_PACKAGES += \
     HoloSpiralWallpaper \


### PR DESCRIPTION
These were removed and building breaks without this being removed as well.
