### PR TITLE
 SystemUpdateService: enable service but lock its receivers (1/3)

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -15,12 +15,20 @@
     <!-- Disable stock OTA components if installed -->
     <string-array name="config_disabledComponents" translatable="false">
         <item>com.google.android.gsf/com.google.android.gsf.update.SystemUpdateActivity</item>
-        <item>com.google.android.gsf/com.google.android.gsf.update.SystemUpdateService</item>
+        <!--item>com.google.android.gsf/com.google.android.gsf.update.SystemUpdateService</item-->
         <item>com.google.android.gsf/com.google.android.gsf.update.SystemUpdateService$Receiver</item>
+        <item>com.google.android.gsf/com.google.android.gsf.update.SystemUpdateService$SecretCodeReceiver</item>
         <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateActivity</item>
-        <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService</item>
+        <!--item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService</item-->
         <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService$Receiver</item>
         <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService$ActiveReceiver</item>
+        <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService$SecretCodeReceiver</item>
+    </string-array>
+
+    <!-- Force enabling of some services that could have been previously disabled -->
+    <string-array name="config_forceEnabledComponents" translatable="false">
+        <item>com.google.android.gsf/com.google.android.gsf.update.SystemUpdateService</item>
+        <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService</item>
     </string-array>
 
     <string name="config_mms_user_agent">CyanogenMod</string>


### PR DESCRIPTION
This takes care of the wakelock issue plaguing recent Carbon and CM-like builds, by reenabling aspects of Google Play Services, but locking it's receivers.

This patch is of three parts, affecting android_vendor_carbon (which does the magic), and android_frameworks_base (declaring the forceEnabledCompnoents array so the magic compiles properly)

Source:
http://review.cyanogenmod.org/#/c/91882/1
